### PR TITLE
Use constants for time durations (2x faster, 3.5x less memory)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 5.3.0 (Next)
 
 * Your contribution here.
+* [#115](https://github.com/radar/distance_of_time_in_words/pull/115): Use constants for time durations (2x faster, 3.5x less memory) - [@krzysiek1507](https://github.com/krzysiek1507)
 
 ## 5.2.0 (2020/10/03)
 

--- a/benchmarks/time_hash_bench.rb
+++ b/benchmarks/time_hash_bench.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'benchmark/ips'
+require 'benchmark/memory'
+require 'active_support/core_ext/numeric'
+require 'active_support/core_ext/integer'
+
+require_relative '../lib/dotiw/time_hash'
+
+from = Time.now
+to = Time.now + 1.year + 2.months + 3.weeks + 4.days + 5.hours + 6.minutes + 7.seconds
+
+%i[ips memory].each do |type|
+  Benchmark.public_send(type) do |x|
+    x.report('master') { DOTIW::TimeHash.new(nil, from, to) }
+
+    x.compare!
+  end
+end

--- a/lib/dotiw/time_hash.rb
+++ b/lib/dotiw/time_hash.rb
@@ -34,6 +34,12 @@ module DOTIW
 
     attr_reader :options, :output
 
+    ONE_MINUTE = 1.minute.freeze
+    ONE_HOUR = 1.hour.freeze
+    ONE_DAY = 1.day.freeze
+    ONE_WEEK = 7.days.freeze
+    FOUR_WEEKS = 28.days.freeze
+
     def build_time_hash
       if accumulate_on = options.delete(:accumulate_on)
         accumulate_on = accumulate_on.to_sym
@@ -42,15 +48,15 @@ module DOTIW
         TIME_FRACTIONS.index(accumulate_on).downto(0) { |i| send("build_#{TIME_FRACTIONS[i]}") }
       else
         while distance > 0
-          if distance < 1.minute
+          if distance < ONE_MINUTE
             build_seconds
-          elsif distance < 1.hour
+          elsif distance < ONE_HOUR
             build_minutes
-          elsif distance < 1.day
+          elsif distance < ONE_DAY
             build_hours
-          elsif distance < 7.days
+          elsif distance < ONE_WEEK
             build_days
-          elsif distance < 28.days
+          elsif distance < FOUR_WEEKS
             build_weeks
           else # greater than a week
             build_years_months_weeks_days
@@ -67,19 +73,19 @@ module DOTIW
     end
 
     def build_minutes
-      output[:minutes], @distance = distance.divmod(1.minute.to_i)
+      output[:minutes], @distance = distance.divmod(ONE_MINUTE.to_i)
     end
 
     def build_hours
-      output[:hours], @distance = distance.divmod(1.hour.to_i)
+      output[:hours], @distance = distance.divmod(ONE_HOUR.to_i)
     end
 
     def build_days
-      output[:days], @distance = distance.divmod(1.day.to_i) unless output[:days]
+      output[:days], @distance = distance.divmod(ONE_DAY.to_i) unless output[:days]
     end
 
     def build_weeks
-      output[:weeks], @distance = distance.divmod(1.week.to_i) unless output[:weeks]
+      output[:weeks], @distance = distance.divmod(ONE_WEEK.to_i) unless output[:weeks]
     end
 
     def build_months
@@ -137,7 +143,7 @@ module DOTIW
       output[:weeks]   = weeks
       output[:days]    = days
 
-      total_days, @distance = distance.abs.divmod(1.day.to_i)
+      total_days, @distance = distance.abs.divmod(ONE_DAY.to_i)
 
       [total_days, @distance]
     end


### PR DESCRIPTION
A small optimization. ;)

Benchmark:
```ruby
require 'benchmark/ips'
require 'benchmark/memory'
require 'date'
require 'active_support/core_ext/numeric'
require 'active_support/core_ext/integer'

require_relative 'optimized'
require_relative 'original'

from = Time.now
to = Time.now + 1.year + 2.months + 3.weeks + 4.days + 5.hours + 6.minutes + 7.seconds

[:ips, :memory].each do |type|
  Benchmark.public_send(type) do |x|
    x.report('optimized') { DOTIW::TimeHashOptimized.new(nil, from, to) }
    x.report('master') { DOTIW::TimeHash.new(nil, from, to) }

    x.compare!
  end
end
```

Results:
```ruby
IPS:
Warming up --------------------------------------
              master     4.040k i/100ms
           optimized     8.728k i/100ms
Calculating -------------------------------------
              master     41.795k (± 5.3%) i/s -    210.080k in   5.040932s
           optimized     90.519k (± 5.2%) i/s -    453.856k in   5.027942s

Comparison:
           optimized:    90518.6 i/s
              master:    41794.8 i/s - 2.17x  (± 0.00) slower

Memory:
Calculating -------------------------------------
              master     6.072k memsize (     0.000  retained)
                        91.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)
           optimized     1.704k memsize (     0.000  retained)
                        35.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)

Comparison:
           optimized:       1704 allocated
              master:       6072 allocated - 3.56x more

```