### PR TITLE
Support `#distance_of_time_in_words_to_now` with `vague: true`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Your contribution here.
 * [#115](https://github.com/radar/distance_of_time_in_words/pull/115): Use constants for time durations (2x faster, 3.5x less memory) - [@krzysiek1507](https://github.com/krzysiek1507)
+* [#117](https://github.com/radar/distance_of_time_in_words/pull/117): Support `#distance_of_time_in_words_to_now` with `vague: true` - [@joshuapinter](https://github.com/joshuapinter)
+
 
 ## 5.2.0 (2020/10/03)
 

--- a/README.markdown
+++ b/README.markdown
@@ -69,11 +69,14 @@ Yes this could just be merged into the options hash but I'm leaving it here to e
 
 The last argument is an optional options hash that can be used to manipulate behavior and (which uses `to_sentence`).
 
-Don't like having to pass in `Time.now` all the time? Then use `time_ago_in_words` which also will *rock your
+Don't like having to pass in `Time.now` all the time? Then use `time_ago_in_words` or `distance_of_time_in_words_to_now` which also will *rock your
 world*:
 
 ```ruby
 >> time_ago_in_words(Time.now + 3.days + 1.second)
+=> "3 days, and 1 second"
+
+>> distance_of_time_in_words_to_now(Time.now + 3.days + 1.second)
 => "3 days, and 1 second"
 ```
 

--- a/lib/dotiw/action_view/helpers/date_helper.rb
+++ b/lib/dotiw/action_view/helpers/date_helper.rb
@@ -9,8 +9,13 @@ module ActionView
       include DOTIW::Methods
 
       def distance_of_time_in_words(from_time, to_time = 0, include_seconds_or_options = {}, options = {})
-        return _distance_of_time_in_words(from_time, to_time, options) if options.delete(:vague)
-        DOTIW::Methods.distance_of_time_in_words(from_time, to_time, include_seconds_or_options, options)
+        return _distance_of_time_in_words(from_time, to_time, options) if options[:vague]
+        DOTIW::Methods.distance_of_time_in_words(from_time, to_time, include_seconds_or_options, options.except(:vague))
+      end
+
+      def distance_of_time_in_words_to_now(to_time = 0, include_seconds_or_options = {}, options = {})
+        return _distance_of_time_in_words(Time.now, to_time, options) if options[:vague]
+        DOTIW::Methods.distance_of_time_in_words(Time.now, to_time, include_seconds_or_options, options.except(:vague))
       end
 
       def distance_of_time_in_percent(from_time, current_time, to_time, options = {})

--- a/spec/lib/dotiw_spec.rb
+++ b/spec/lib/dotiw_spec.rb
@@ -350,6 +350,32 @@ describe 'A better distance_of_time_in_words' do
             actual = ActionController::Base.helpers.time_ago_in_words(Time.now - 3.days - 14.minutes)
             expect(actual).to eq(expected)
           end
+
+          describe '#distance_of_time_in_words_to_now' do
+            context 'without options' do
+              it 'shows detailed duration' do
+                expected = '3 days and 14 minutes'
+                actual = ActionController::Base.helpers.distance_of_time_in_words_to_now(Time.now - 3.days - 14.minutes)
+                expect(actual).to eq(expected)
+              end
+            end
+
+            context 'with vague option true' do
+              it 'shows vague duration' do
+                expected = '3 days'
+                actual = ActionController::Base.helpers.distance_of_time_in_words_to_now(Time.now - 3.days - 14.minutes, false, vague: true)
+                expect(actual).to eq(expected)
+              end
+            end
+
+            context 'with vague option false' do
+              it 'shows detailed duration' do
+                expected = '3 days and 14 minutes'
+                actual = ActionController::Base.helpers.distance_of_time_in_words_to_now(Time.now - 3.days - 14.minutes, false, vague: false)
+                expect(actual).to eq(expected)
+              end
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
Now you can pass `distance_of_time_in_words_to_now` with `vague: true` and get a vague response.

## Before

```ruby
$ distance_of_time_in_words_to_now( Time.now + 1.day )
#=> "23 hours and 59 minutes"     

$ distance_of_time_in_words_to_now( Time.now + 1.day, false, vague: true )
#=> ArgumentError: wrong number of arguments (given 3, expected 1..2)

$ distance_of_time_in_words_to_now( Time.now + 1.day, vague: true )
#=> ArgumentError: Unknown key: :vague. Valid keys are: :words_connector, :two_words_connector, :last_word_connector, :locale
```

## After

```ruby
$ distance_of_time_in_words_to_now( Time.now + 1.day )
#=> "23 hours and 59 minutes"     

$ distance_of_time_in_words_to_now( Time.now + 1.day, false, vague: true )
#=> "1 day"

$ distance_of_time_in_words_to_now( Time.now + 1.day, vague: true )
#=> ArgumentError: Unknown key: :vague. Valid keys are: :words_connector, :two_words_connector, :last_word_connector, :locale
```

In short, dotiw was not handling this Rails method at all, unlike how it was handling `time_ago_in_words`. This rectifies that and makes it act like the other methods.
