### PR TITLE
Argument error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * [#115](https://github.com/radar/distance_of_time_in_words/pull/115): Use constants for time durations (2x faster, 3.5x less memory) - [@krzysiek1507](https://github.com/krzysiek1507).
 * [#117](https://github.com/radar/distance_of_time_in_words/pull/117): Support `#distance_of_time_in_words_to_now` with `vague: true` - [@joshuapinter](https://github.com/joshuapinter).
+* [#118](https://github.com/radar/distance_of_time_in_words/pull/118): Raise `ArgumentError` when `nil` is passed for time, to match original `distance_of_time_in_words` - [@joshuapinter](https://github.com/joshuapinter).
 * Your contribution here.
 
 ## 5.2.0 (2020/10/03)

--- a/lib/dotiw/methods.rb
+++ b/lib/dotiw/methods.rb
@@ -17,6 +17,8 @@ module DOTIW
     end
 
     def distance_of_time_in_words(from_time, to_time = 0, include_seconds_or_options = {}, options = {})
+      raise ArgumentError.new("nil can't be converted to a Time value") if from_time.nil? || to_time.nil?
+
       if include_seconds_or_options.is_a?(Hash)
         options = include_seconds_or_options
       else

--- a/spec/lib/dotiw_spec.rb
+++ b/spec/lib/dotiw_spec.rb
@@ -101,6 +101,11 @@ describe 'A better distance_of_time_in_words' do
         expect(DOTIW.languages.map(&:to_s).sort).to eq languages.sort
       end
 
+      it 'raises ArgumentError when nil is passed for time' do
+        expect { distance_of_time_in_words(nil) }.to raise_error(ArgumentError)
+        expect { distance_of_time_in_words(nil, nil) }.to raise_error(ArgumentError)
+      end
+
       DOTIW.languages.each do |lang|
         context lang do
           YAML.safe_load(
@@ -352,6 +357,12 @@ describe 'A better distance_of_time_in_words' do
           end
 
           describe '#distance_of_time_in_words_to_now' do
+            context 'with nil' do
+              it 'raises ArgumentError when nil is passed for time' do
+                expect { ActionController::Base.helpers.distance_of_time_in_words_to_now(nil) }.to raise_error(ArgumentError)
+              end
+            end
+
             context 'without options' do
               it 'shows detailed duration' do
                 expected = '3 days and 14 minutes'


### PR DESCRIPTION
## Raise `ArgumentError` when `nil` is passed for time.

This matches the default behaviour of `distance_of_time_in_words`.

Fixes #85.


### After this commit

```ruby
$ distance_of_time_in_words( nil )
#=> ArgumentError (nil can't be converted to a Time value)

$ distance_of_time_in_words( nil, nil, false, vague: true )
#=> ArgumentError (nil can't be converted to a Time value)

$ distance_of_time_in_words_to_now( nil )
#=> ArgumentError (nil can't be converted to a Time value)

$ distance_of_time_in_words_to_now( nil, false, vague: true )
#=> ArgumentError (nil can't be converted to a Time value)

$ time_ago_in_words( nil )
#=> ArgumentError (nil can't be converted to a Time value)
```