### PR TITLE
Do not mutate options.

### DIFF
--- a/lib/dotiw/methods.rb
+++ b/lib/dotiw/methods.rb
@@ -12,8 +12,11 @@ module DOTIW
     end
 
     def distance_of_time(seconds, options = {})
-      options[:include_seconds] ||= true
-      _display_time_in_words DOTIW::TimeHash.new(seconds, nil, nil, options_with_scope(options)).to_hash, options
+      options = options_with_scope(options).reverse_merge(
+        include_seconds: true
+      )
+      options.delete(:compact)
+      _display_time_in_words DOTIW::TimeHash.new(seconds, nil, nil, options).to_hash, options
     end
 
     def distance_of_time_in_words(from_time, to_time = 0, include_seconds_or_options = {}, options = {})
@@ -22,6 +25,7 @@ module DOTIW
       if include_seconds_or_options.is_a?(Hash)
         options = include_seconds_or_options
       else
+        options = options.dup
         options[:include_seconds] ||= !!include_seconds_or_options
       end
       return distance_of_time(from_time, options) if to_time == 0
@@ -38,12 +42,15 @@ module DOTIW
     private
 
     def options_with_scope(options)
-      options.merge!({:scope => DOTIW::DEFAULT_I18N_SCOPE_COMPACT}) if options.delete(:compact)
-      options
+      if options.key?(:compact)
+        options.merge({:scope => DOTIW::DEFAULT_I18N_SCOPE_COMPACT})
+      else
+        options
+      end
     end
 
     def _display_time_in_words(hash, options = {})
-      options.reverse_merge!(
+      options = options.reverse_merge(
         include_seconds: false
       ).symbolize_keys!
 
@@ -95,7 +102,7 @@ module DOTIW
                                                        default: :'support.array.last_word_connector',
                                                        locale: options[:locale]
 
-      output.to_sentence(options)
+      output.to_sentence(options.except(:accumulate_on))
     end
   end
 end # DOTIW

--- a/lib/dotiw/time_hash.rb
+++ b/lib/dotiw/time_hash.rb
@@ -8,7 +8,7 @@ module DOTIW
 
     def initialize(distance, from_time, to_time = nil, options = {})
       @output     = {}
-      @options    = options
+      @options    = options.dup
       @distance   = distance
       @from_time  = from_time || Time.current
       @to_time    = to_time   || (@to_time_not_given = true && @from_time + distance.seconds)
@@ -41,7 +41,7 @@ module DOTIW
     FOUR_WEEKS = 28.days.freeze
 
     def build_time_hash
-      if accumulate_on = options.delete(:accumulate_on)
+      if accumulate_on = options[:accumulate_on]
         accumulate_on = accumulate_on.to_sym
         return build_time_hash if accumulate_on == :years
 


### PR DESCRIPTION
We shouldn't modify input hash parameters as it could affect that object for other calls outside of this method.

Read up on it here:

https://code.dblock.org/2020/11/11/dup-dont-modify-input-hash-parameters-in-ruby.html

Fixes #113.