### PR TITLE
After upgrade from 4.0.1 to 5.3.1 option[:vague] raises error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 5.3.2 (Next)
 
-* Your contribution here.
+* [#126](https://github.com/radar/distance_of_time_in_words/pull/126): Fixes `#distance_of_time_in_words_to_now` with `vague: true` when supplied without include_seconds argument - [@mozcomp](https://github.com/mozcomp)
 
 ## 5.3.1 (2021/03/26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 5.3.2 (Next)
 
 * Your contribution here.
-* [#126](https://github.com/radar/distance_of_time_in_words/pull/126): Fixes `#distance_of_time_in_words_to_now` with `vague: true` when supplied without `include_seconds` argument - [@mozcomp](https://github.com/mozcomp)
+* [#126](https://github.com/radar/distance_of_time_in_words/pull/126): Fixes `#distance_of_time_in_words_to_now` with `vague: true` when supplied without `include_seconds` argument - [@mozcomp](https://github.com/mozcomp).
 
 ## 5.3.1 (2021/03/26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 5.3.2 (Next)
 
-* [#126](https://github.com/radar/distance_of_time_in_words/pull/126): Fixes `#distance_of_time_in_words_to_now` with `vague: true` when supplied without include_seconds argument - [@mozcomp](https://github.com/mozcomp)
+- * Your contribution here.
 
 ## 5.3.1 (2021/03/26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 5.3.2 (Next)
 
-- * Your contribution here.
+* Your contribution here.
+* [#126](https://github.com/radar/distance_of_time_in_words/pull/126): Fixes `#distance_of_time_in_words_to_now` with `vague: true` when supplied without `include_seconds` argument - [@mozcomp](https://github.com/mozcomp)
 
 ## 5.3.1 (2021/03/26)
 

--- a/README.markdown
+++ b/README.markdown
@@ -65,7 +65,8 @@ The third argument for this method is whether or not to include seconds. By defa
 => "1 year, and 1 second"
 ```
 
-Yes this could just be merged into the options hash but I'm leaving it here to ensure "backwards-compatibility", because that's just an insanely radical thing to do. \m/
+Yes this could just be merged into the options hash but I'm leaving it here to ensure "backwards-compatibility", because that's just an insanely radical thing to do.  
+Alternatively this can be included in the options hash as `include_seconds: true` removing this argument altogether.
 
 The last argument is an optional options hash that can be used to manipulate behavior and (which uses `to_sentence`).
 
@@ -98,6 +99,10 @@ This will also be passed to `to_sentence`.
 #### :vague
 
 Specify this if you want it to use the old `distance_of_time_in_words`. The value can be anything except `nil` or `false`.
+
+#### :include_seconds
+
+As described above this option is the equivalent to the third argument whether to include seconds.
 
 #### :accumulate_on
 

--- a/lib/dotiw/action_view/helpers/date_helper.rb
+++ b/lib/dotiw/action_view/helpers/date_helper.rb
@@ -9,23 +9,25 @@ module ActionView
       include DOTIW::Methods
 
       def distance_of_time_in_words(from_time, to_time = 0, include_seconds_or_options = {}, options = {})
-        unless ([true, false].include? include_seconds_or_options) || options.present?
+        if include_seconds_or_options.is_a?(Hash)
           options = include_seconds_or_options
-          include_seconds_or_options = nil
+        else
+          options[:include_seconds] ||= !!include_seconds_or_options
         end
         return _distance_of_time_in_words(from_time, to_time, options.except(:vague)) if options[:vague]
 
-        DOTIW::Methods.distance_of_time_in_words(from_time, to_time, include_seconds_or_options, options.except(:vague))
+        DOTIW::Methods.distance_of_time_in_words(from_time, to_time, options.except(:vague))
       end
 
       def distance_of_time_in_words_to_now(to_time = 0, include_seconds_or_options = {}, options = {})
-        unless ([true, false].include? include_seconds_or_options) || options.present?
+        if include_seconds_or_options.is_a?(Hash)
           options = include_seconds_or_options
-          include_seconds_or_options = nil
+        else
+          options[:include_seconds] ||= !!include_seconds_or_options
         end
         return _distance_of_time_in_words(Time.now, to_time, options.except(:vague)) if options[:vague]
 
-        DOTIW::Methods.distance_of_time_in_words(Time.now, to_time, include_seconds_or_options, options.except(:vague))
+        DOTIW::Methods.distance_of_time_in_words(Time.now, to_time, options.except(:vague))
       end
 
       def distance_of_time_in_percent(from_time, current_time, to_time, options = {})

--- a/lib/dotiw/action_view/helpers/date_helper.rb
+++ b/lib/dotiw/action_view/helpers/date_helper.rb
@@ -32,14 +32,13 @@ module ActionView
 
       private
       def merge_options(include_seconds_or_options, options)
-        merged_options = options.dup
         if include_seconds_or_options.is_a?(Hash)
-          merged_options.merge!(include_seconds_or_options)
+          options.merge(include_seconds_or_options)
         else
-          merged_options.merge!(include_seconds: !!include_seconds_or_options)
+          options.merge(include_seconds: !!include_seconds_or_options)
         end
       end
-
+      
     end
   end
 end

--- a/lib/dotiw/action_view/helpers/date_helper.rb
+++ b/lib/dotiw/action_view/helpers/date_helper.rb
@@ -9,22 +9,14 @@ module ActionView
       include DOTIW::Methods
 
       def distance_of_time_in_words(from_time, to_time = 0, include_seconds_or_options = {}, options = {})
-        if include_seconds_or_options.is_a?(Hash)
-          options = include_seconds_or_options
-        else
-          options[:include_seconds] ||= !!include_seconds_or_options
-        end
+        options = merge_options(include_seconds_or_options, options)
         return _distance_of_time_in_words(from_time, to_time, options.except(:vague)) if options[:vague]
 
         DOTIW::Methods.distance_of_time_in_words(from_time, to_time, options.except(:vague))
       end
 
       def distance_of_time_in_words_to_now(to_time = 0, include_seconds_or_options = {}, options = {})
-        if include_seconds_or_options.is_a?(Hash)
-          options = include_seconds_or_options
-        else
-          options[:include_seconds] ||= !!include_seconds_or_options
-        end
+        options = merge_options(include_seconds_or_options, options)
         return _distance_of_time_in_words(Time.now, to_time, options.except(:vague)) if options[:vague]
 
         DOTIW::Methods.distance_of_time_in_words(Time.now, to_time, options.except(:vague))
@@ -37,6 +29,17 @@ module ActionView
         result = ((current_time - from_time) / distance) * 100
         number_with_precision(result, options).to_s + '%'
       end
+
+      private
+      def merge_options(include_seconds_or_options, options)
+        merged_options = options.dup
+        if include_seconds_or_options.is_a?(Hash)
+          merged_options.merge!(include_seconds_or_options)
+        else
+          merged_options.merge!(include_seconds: !!include_seconds_or_options)
+        end
+      end
+
     end
   end
 end

--- a/lib/dotiw/action_view/helpers/date_helper.rb
+++ b/lib/dotiw/action_view/helpers/date_helper.rb
@@ -9,7 +9,7 @@ module ActionView
       include DOTIW::Methods
 
       def distance_of_time_in_words(from_time, to_time = 0, include_seconds_or_options = {}, options = {})
-        unless [true, false].include? include_seconds_or_options
+        unless ([true, false].include? include_seconds_or_options) || options.present?
           options = include_seconds_or_options
           include_seconds_or_options = nil
         end
@@ -19,7 +19,7 @@ module ActionView
       end
 
       def distance_of_time_in_words_to_now(to_time = 0, include_seconds_or_options = {}, options = {})
-        unless [true, false].include? include_seconds_or_options
+        unless ([true, false].include? include_seconds_or_options) || options.present?
           options = include_seconds_or_options
           include_seconds_or_options = nil
         end

--- a/lib/dotiw/action_view/helpers/date_helper.rb
+++ b/lib/dotiw/action_view/helpers/date_helper.rb
@@ -9,13 +9,21 @@ module ActionView
       include DOTIW::Methods
 
       def distance_of_time_in_words(from_time, to_time = 0, include_seconds_or_options = {}, options = {})
-        return _distance_of_time_in_words(from_time, to_time, options) if options[:vague]
+        unless [true, false].include? include_seconds_or_options
+          options = include_seconds_or_options
+          include_seconds_or_options = nil
+        end
+        return _distance_of_time_in_words(from_time, to_time, options.except(:vague)) if options[:vague]
 
         DOTIW::Methods.distance_of_time_in_words(from_time, to_time, include_seconds_or_options, options.except(:vague))
       end
 
       def distance_of_time_in_words_to_now(to_time = 0, include_seconds_or_options = {}, options = {})
-        return _distance_of_time_in_words(Time.now, to_time, options) if options[:vague]
+        unless [true, false].include? include_seconds_or_options
+          options = include_seconds_or_options
+          include_seconds_or_options = nil
+        end
+        return _distance_of_time_in_words(Time.now, to_time, options.except(:vague)) if options[:vague]
 
         DOTIW::Methods.distance_of_time_in_words(Time.now, to_time, include_seconds_or_options, options.except(:vague))
       end

--- a/spec/lib/dotiw_spec.rb
+++ b/spec/lib/dotiw_spec.rb
@@ -320,7 +320,34 @@ describe 'A better distance_of_time_in_words' do
     end
 
     if defined?(ActionView)
-      describe 'ActionView' do
+      describe 'ActionView without include seconds argument' do
+        [
+          [START_TIME,
+          START_TIME + 1.year + 2.months + 3.weeks + 4.days + 5.hours + 6.minutes + 7.seconds,
+          { vague: true },
+          'about 1 year'],
+          [START_TIME,
+          START_TIME + 1.year + 2.months + 3.weeks + 4.days + 5.hours + 6.minutes + 7.seconds,
+          { vague: 'Yes please' },
+          'about 1 year'],
+          [START_TIME,
+          START_TIME + 1.year + 2.months + 3.weeks + 4.days + 5.hours + 6.minutes + 7.seconds,
+          { vague: false },
+          '1 year, 2 months, 3 weeks, 4 days, 5 hours, and 6 minutes'],
+          [START_TIME,
+          START_TIME + 1.year + 2.months + 3.weeks + 4.days + 5.hours + 6.minutes + 7.seconds,
+          { vague: nil },
+          '1 year, 2 months, 3 weeks, 4 days, 5 hours, and 6 minutes']
+        ].each do |start, finish, options, output|
+          it "should be #{output}" do
+            expect(distance_of_time_in_words(start, finish, options)).to eq(output)
+          end
+        end
+      end
+    end
+
+    if defined?(ActionView)
+      describe 'ActionView with include seconds argument' do
         [
           [START_TIME,
            START_TIME + 1.year + 2.months + 3.weeks + 4.days + 5.hours + 6.minutes + 7.seconds,
@@ -343,7 +370,7 @@ describe 'A better distance_of_time_in_words' do
             expect(distance_of_time_in_words(start, finish, true, options)).to eq(output)
           end
         end
-
+  
         context 'via ActionController::Base.helpers' do
           it '#distance_of_time_in_words' do
             end_time = START_TIME + 1.year + 2.months + 3.weeks + 4.days + 5.hours + 6.minutes + 7.seconds

--- a/spec/lib/dotiw_spec.rb
+++ b/spec/lib/dotiw_spec.rb
@@ -396,32 +396,93 @@ describe 'A better distance_of_time_in_words' do
             end
 
             context 'without options' do
-              it 'shows detailed duration' do
+              it 'shows detailed duration without seconds' do
                 expected = '3 days and 14 minutes'
                 actual = ActionController::Base.helpers.distance_of_time_in_words_to_now(Time.now - 3.days - 14.minutes)
                 expect(actual).to eq(expected)
               end
             end
 
-            context 'with vague option true' do
+            context 'with seconds false and vague option true' do
               it 'shows vague duration' do
                 expected = '3 days'
                 actual = ActionController::Base.helpers.distance_of_time_in_words_to_now(
-                  Time.now - 3.days - 14.minutes, false, vague: true
+                  Time.now - 3.days - 14.minutes - 20.seconds, false, vague: true
                 )
                 expect(actual).to eq(expected)
               end
             end
 
-            context 'with vague option false' do
-              it 'shows detailed duration' do
-                expected = '3 days and 14 minutes'
+            context 'with seconds true and vague option true' do
+              it 'shows vague duration' do
+                expected = '3 days'
                 actual = ActionController::Base.helpers.distance_of_time_in_words_to_now(
-                  Time.now - 3.days - 14.minutes, false, vague: false
+                  Time.now - 3.days - 14.minutes - 20.seconds, true, vague: true
                 )
                 expect(actual).to eq(expected)
               end
             end
+
+            context 'with seconds false and vague option false' do
+              it 'shows detailed duration without seconds' do
+                expected = '3 days and 14 minutes'
+                actual = ActionController::Base.helpers.distance_of_time_in_words_to_now(
+                  Time.now - 3.days - 14.minutes - 20.seconds, false, vague: false
+                )
+                expect(actual).to eq(expected)
+              end
+            end
+
+            context 'with seconds true and vague option false' do
+              it 'shows detailed duration with seconds' do
+                expected = '3 days, 14 minutes, and 20 seconds'
+                actual = ActionController::Base.helpers.distance_of_time_in_words_to_now(
+                  Time.now - 3.days - 14.minutes - 20.seconds, true, vague: false
+                )
+                expect(actual).to eq(expected)
+              end
+            end
+
+            context 'without seconds and vague option false' do
+              it 'shows detailed duration without seconds' do
+                expected = '3 days and 14 minutes'
+                actual = ActionController::Base.helpers.distance_of_time_in_words_to_now(
+                  Time.now - 3.days - 14.minutes - 20.seconds, vague: false
+                )
+                expect(actual).to eq(expected)
+              end
+            end
+
+            context 'without seconds and vague option true' do
+              it 'shows vague duration' do
+                expected = '3 days'
+                actual = ActionController::Base.helpers.distance_of_time_in_words_to_now(
+                  Time.now - 3.days - 14.minutes - 20.seconds, vague: true
+                )
+                expect(actual).to eq(expected)
+              end
+            end
+
+            context 'with options include_seconds true and vague option false' do
+              it 'shows detailed duration with seconds' do
+                expected = '3 days, 14 minutes, and 20 seconds'
+                actual = ActionController::Base.helpers.distance_of_time_in_words_to_now(
+                  Time.now - 3.days - 14.minutes - 20.seconds, {include_seconds: true, vague: false}
+                )
+                expect(actual).to eq(expected)
+              end
+            end
+
+            context 'with options include_seconds false and vague option true' do
+              it 'shows vague duration' do
+                expected = '3 days'
+                actual = ActionController::Base.helpers.distance_of_time_in_words_to_now(
+                  Time.now - 3.days - 14.minutes - 20.seconds, {include_seconds: false, vague: true}
+                )
+                expect(actual).to eq(expected)
+              end
+            end
+
           end
         end
       end


### PR DESCRIPTION
In relation to Issue: #125 

Following further tests as to cause of the issue, it relates to the interaction between the optional 3rd argument for "include seconds" and the 4th argument "options". If the 3rd argument was supplied (true/false), then the code worked as expected.
This was included and passed in spec tests.
Adding same specs, but without the optional "include_seconds" argument, gave a series of fails as found in the Issue raised.

My solution may not be acceptable, as I'm changing the arguments supplied, but by testing for a valid true/false of the "include_seconds" argument, and if "options" are nil, then swap the contents.

Once this is done, with the minor tweak of excluding the vague option before passing to the ActiveSupport support version, the code now passes all tests.


