### PR TITLE
Measure distance when from_time is numeric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 5.3.3 (Next)
 
 * Your contribution here.
+* [#128](https://github.com/radar/distance_of_time_in_words/pull/128): Adds support for numeric values for both the `from_time` and `to_time` arguments in the `#distance_of_time_in_words` helper - [@bjedrocha](https://github.com/bjedrocha).
 
 ## 5.3.2 (2021/11/08)
 

--- a/README.markdown
+++ b/README.markdown
@@ -58,6 +58,22 @@ Better than "about 1 year", am I right? Of course I am.
 => "1 second"
 ```
 
+It also supports numeric arguments like the original Rails version:
+
+```ruby
+>> distance_of_time_in_words(0, 150)
+=> "2 minutes and 30 seconds"
+```
+
+as an alternative to:
+
+```ruby
+>> distance_of_time_in_words(Time.now, Time.now + 2.5.minutes)
+=> "2 minutes and 30 seconds"
+```
+
+This is useful if you're just interested in "stringifying" the length of time. Alternatively, you can use the `#distance_of_time` helper as described [below](#distance\_of\_time).
+
 The third argument for this method is whether or not to include seconds. By default this is `false` (because in Rails' `distance_of_time_in_words` it is), you can turn it on though by passing `true` as the third argument:
 
 ```ruby

--- a/lib/dotiw/methods.rb
+++ b/lib/dotiw/methods.rb
@@ -20,7 +20,9 @@ module DOTIW
     end
 
     def distance_of_time_in_words(from_time, to_time = 0, include_seconds_or_options = {}, options = {})
-      raise ArgumentError, "nil can't be converted to a Time value" if from_time.nil? || to_time.nil?
+      from_time = normalize_distance_of_time_argument_to_time(from_time)
+      to_time = normalize_distance_of_time_argument_to_time(to_time)
+      from_time, to_time = to_time, from_time if from_time > to_time
 
       if include_seconds_or_options.is_a?(Hash)
         options = include_seconds_or_options
@@ -28,7 +30,8 @@ module DOTIW
         options = options.dup
         options[:include_seconds] ||= !!include_seconds_or_options
       end
-      return distance_of_time(from_time, options) if to_time == 0
+
+      return distance_of_time(to_time.to_i, options) if from_time.to_i == 0
 
       options = options_with_scope(options)
       hash = distance_of_time_in_words_hash(from_time, to_time, options)
@@ -40,6 +43,16 @@ module DOTIW
     end
 
     private
+
+    def normalize_distance_of_time_argument_to_time(value)
+      if value.is_a?(Numeric)
+        Time.at(value)
+      elsif value.respond_to?(:to_time)
+        value.to_time
+      else
+        raise ArgumentError, "#{value.inspect} can't be converted to a Time value"
+      end
+    end
 
     def options_with_scope(options)
       if options.key?(:compact)

--- a/spec/lib/dotiw_spec.rb
+++ b/spec/lib/dotiw_spec.rb
@@ -101,11 +101,6 @@ describe 'A better distance_of_time_in_words' do
         expect(DOTIW.languages.map(&:to_s).sort).to eq languages.sort
       end
 
-      it 'raises ArgumentError when nil is passed for time' do
-        expect { distance_of_time_in_words(nil) }.to raise_error(ArgumentError)
-        expect { distance_of_time_in_words(nil, nil) }.to raise_error(ArgumentError)
-      end
-
       DOTIW.languages.each do |lang|
         context lang do
           YAML.safe_load(
@@ -238,6 +233,38 @@ describe 'A better distance_of_time_in_words' do
       ].each do |start, output|
         it "should be #{output}" do
           expect(distance_of_time_in_words(start)).to eq(output)
+        end
+      end
+    end
+
+    describe 'with mixed inputs' do
+      # Further backwards compatability with the original rails
+      # distance_of_time_in_words helper.
+      [
+        [0, 2.5.minutes.to_i, '2 minutes and 30 seconds'],
+        [10.minutes.to_i, 0, '10 minutes'],
+        [0, 24.weeks.to_i, '5 months, 2 weeks, and 1 day'],
+        [0, 0, 'less than 1 second'],
+      ].each do |start, finish, output|
+        it "should be #{output}" do
+          expect(distance_of_time_in_words(start, finish)).to eq(output)
+        end
+      end
+
+      context "of which one or both can't be converted to a Time value" do
+        let(:invalid_inputs) do
+          [
+            [nil, 5.minutes],
+            [nil, double(:does_not_respond_to_time)],
+            [nil],
+            [nil, nil],
+          ]
+        end
+
+        it "should raise an ArgumentError" do
+          invalid_inputs.each do |start, finish|
+            expect { distance_of_time_in_words(start, finish) }.to raise_error(ArgumentError)
+          end
         end
       end
     end


### PR DESCRIPTION
The original Rails `distance_of_time_in_words` supports numeric arguments for **both** the `from_time` and `to_time` arguments whereas this breaks when doing things like `distance_of_time_in_words(0, 2.minutes)`. I've noticed that you already support the use-case when `to_time` is a numeric by returning the `distance_of_time` value so this piggy-backs onto that logic.