### PR TITLE
Fix bug with Russian translations for 21, 31, 41... numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [#134](https://github.com/radar/distance_of_time_in_words/pull/134): Add support for Dzongkha, the National language of Bhutan - [@KinWang-2013](https://github.com/KinWang-2013).
 * [#135](https://github.com/radar/distance_of_time_in_words/pull/135): Add support for Ruby 2.7 and 3.2, removed support for ruby 2.4, 2.5, 2.6 and Rails 4 - [@KinWang-2013](https://github.com/KinWang-2013).
 * [#136](https://github.com/radar/distance_of_time_in_words/pull/136): Add support for Rails 7 - [@KinWang-2013](https://github.com/KinWang-2013).
+* [#139](https://github.com/radar/distance_of_time_in_words/pull/139): Fix bug with pluralization of Russian translations for numbers ending in 1 - [bitberry-dev](https://github.com/bitberry-dev).
 * Your contribution here.
 
 ## 5.3.3 (2022/04/25)

--- a/lib/dotiw/locale/ru.yml
+++ b/lib/dotiw/locale/ru.yml
@@ -39,22 +39,22 @@ ru:
       less_than_x: "меньше, чем %{distance}"
     dotiw_compact:
       seconds:
-        one: 1с
+        one: "%{count}с"
         other: "%{count}с"
       minutes:
-        one: 1м
+        one: "%{count}м"
         other: "%{count}м"
       hours:
-        one: 1ч
+        one: "%{count}ч"
         other: "%{count}ч"
       days:
-        one: 1д
+        one: "%{count}д"
         other: "%{count}д"
       weeks:
-        one: 1н
+        one: "%{count}н"
         other: "%{count}н"
       months:
-        one: 1ме
+        one: "%{count}ме"
         other: "%{count}ме"
       years:
         one:   "%{count}г"
@@ -66,11 +66,11 @@ ru:
       two_words_connector: ""
       last_word_connector: ""
       about_x_years:
-        one: ~1г
+        one: "~%{count}г"
         any: "~%{count}г"
       over_x_years:
-        one: ">1г"
+        one: ">%{count}г"
         other: ">%{count}г"
       almost_x_years:
-        one: ~1г
+        one: "~%{count}г"
         any: "~%{count}г"

--- a/spec/lib/dotiw_spec.rb
+++ b/spec/lib/dotiw_spec.rb
@@ -113,12 +113,18 @@ describe 'A better distance_of_time_in_words' do
             context category do
               fixtures.each_pair do |k, v|
                 it v do
+                  options = {
+                    locale: lang
+                  }
+
+                  options[:compact] = true if category.split.include?('compact')
+
                   expect(
                     distance_of_time_in_words(
                       START_TIME,
                       START_TIME + eval(k),
                       true,
-                      locale: lang
+                      options
                     )
                   ).to eq(v)
                 end

--- a/spec/lib/i18n/ru.yml
+++ b/spec/lib/i18n/ru.yml
@@ -3,3 +3,21 @@ seconds:
   1.second: 1 секунда
 minutes:
   1.minute: 1 минута
+compact seconds:
+  1.second: 1с
+  11.seconds: 11с
+  21.seconds: 21с
+compact minutes:
+  1.minute: 1м
+  11.minutes: 11м
+  21.minutes: 21м
+compact hours:
+  1.hour: 1ч
+  11.hours: 11ч
+  21.hours: 21ч
+compact days:
+  1.day: 1д
+compact years:
+  1.year: 1г
+  11.years: 11г
+  21.years: 21г


### PR DESCRIPTION
Hello!

In Russian, numbers like 21, 31, 41, and so on require the singular form of the word, due to a grammatical rule that applies to numbers ending in 1 (except for 11).

Previously, this caused translations to always show "1s", "1m", "1d", etc., for numbers like 21, 31, and 41. I've fixed this issue.